### PR TITLE
ci: removing linkage-monitor from the required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,7 +10,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - lint
       - clirr
       - units (8)
@@ -26,7 +25,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - lint
       - clirr
       - units (7)

--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ If you are using Maven, add this to your pom.xml file:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-resource-settings</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-compile 'com.google.cloud:google-cloud-resource-settings:1.0.1'
+compile 'com.google.cloud:google-cloud-resource-settings:1.0.2'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-resource-settings" % "1.0.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-resource-settings" % "1.0.2"
 ```
 
 ## Authentication


### PR DESCRIPTION
Linkage Monitor is no longer needed, because the Libraries BOM synchronizes with Google Cloud BOM and the shared dependencies BOM https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2137